### PR TITLE
feat: Add API Response Utility Helper

### DIFF
--- a/src/__tests__/app.test.js
+++ b/src/__tests__/app.test.js
@@ -8,7 +8,12 @@ describe('App', () => {
         .get('/api/health')
         .expect(200);
 
-      expect(response.body).toEqual({ status: 'ok' });
+      expect(response.body).toEqual({
+        success: true,
+        statusCode: 200,
+        message: 'Server is healthy',
+        data: { status: 'ok' },
+      });
     });
   });
 });

--- a/src/__tests__/response.test.js
+++ b/src/__tests__/response.test.js
@@ -1,0 +1,66 @@
+const { sendSuccess, sendError } = require('../utils/response');
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('Response Utility', () => {
+  describe('sendSuccess', () => {
+    it('should return 200 with default values', () => {
+      const res = mockRes();
+      sendSuccess(res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        statusCode: 200,
+        message: 'Success',
+        data: {},
+      });
+    });
+
+    it('should return the provided statusCode, message and data', () => {
+      const res = mockRes();
+      sendSuccess(res, { id: 1 }, 201, 'Created');
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        statusCode: 201,
+        message: 'Created',
+        data: { id: 1 },
+      });
+    });
+  });
+
+  describe('sendError', () => {
+    it('should return 500 with default values', () => {
+      const res = mockRes();
+      sendError(res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        statusCode: 500,
+        message: 'An error occurred',
+        data: {},
+      });
+    });
+
+    it('should return the provided statusCode and message', () => {
+      const res = mockRes();
+      sendError(res, 'Not found', 404);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        statusCode: 404,
+        message: 'Not found',
+        data: {},
+      });
+    });
+  });
+});

--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const helmet = require('helmet');
 const morgan = require('morgan');
+const { sendSuccess } = require('./utils/response');
 
 const app = express();
 
@@ -17,7 +18,7 @@ app.use(helmet());
 app.use(morgan('dev'));
 
 app.get('/api/health', (req, res) => {
-  res.status(200).json({ status: 'ok' });
+  sendSuccess(res, { status: 'ok' }, 200, 'Server is healthy');
 });
 
 // Global error handling middleware - must be registered last

--- a/src/utils/response.js
+++ b/src/utils/response.js
@@ -1,0 +1,32 @@
+/**
+ * Send a standardized success response.
+ * @param {import('express').Response} res
+ * @param {*} data
+ * @param {number} statusCode
+ * @param {string} message
+ */
+const sendSuccess = (res, data = {}, statusCode = 200, message = 'Success') => {
+  return res.status(statusCode).json({
+    success: true,
+    statusCode,
+    message,
+    data,
+  });
+};
+
+/**
+ * Send a standardized error response.
+ * @param {import('express').Response} res
+ * @param {string} message
+ * @param {number} statusCode
+ */
+const sendError = (res, message = 'An error occurred', statusCode = 500) => {
+  return res.status(statusCode).json({
+    success: false,
+    statusCode,
+    message,
+    data: {},
+  });
+};
+
+module.exports = { sendSuccess, sendError };


### PR DESCRIPTION
 Here's a summary of what was done:

  New file: 
    src/utils/response.js sendSuccess(res, data, statusCode, message)  defaults to 200 / 'Success'
  - sendError(res, message, statusCode)  defaults to 500 / 'An error occurred'  
  - Both return the standardized shape: { success, statusCode, message, data }

  Updated: src/app.js
  - Imports sendSuccess and uses it in the /api/health endpoint

  Updated: src/__tests__/app.test.js
  - Health check assertion updated to match the new response shape

  New file: src/__tests__/response.test.js
  - 4 tests covering default and custom args for both helpers — 100% coverage

<img width="965" height="505" alt="Screenshot (1640)" src="https://github.com/user-attachments/assets/b8ebba62-604a-4a01-b4da-03b6dee5da70" />

  
  closes #8