### PR TITLE
feat: add admin role change endpoint with self-demotion protection

### DIFF
--- a/src/__tests__/admin.users.controller.test.js
+++ b/src/__tests__/admin.users.controller.test.js
@@ -1,0 +1,107 @@
+const User = require('../models/User.model');
+const { updateUserRole } = require('../controllers/admin.users.controller');
+
+jest.mock('../models/User.model', () => ({
+  findById: jest.fn(),
+}));
+
+describe('Admin user role management', () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    req = {
+      params: { id: '507f1f77bcf86cd799439011' },
+      body: { role: 'admin' },
+      userId: '507f1f77bcf86cd799439012',
+    };
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    next = jest.fn();
+  });
+
+  it('allows an admin to promote another user', async () => {
+    const user = {
+      id: '507f1f77bcf86cd799439011',
+      email: 'alice@example.com',
+      role: 'user',
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    User.findById.mockResolvedValue(user);
+
+    await updateUserRole(req, res, next);
+
+    expect(User.findById).toHaveBeenCalledWith('507f1f77bcf86cd799439011');
+    expect(user.role).toBe('admin');
+    expect(user.save).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      statusCode: 200,
+      message: 'User role updated successfully',
+      data: {
+        id: '507f1f77bcf86cd799439011',
+        email: 'alice@example.com',
+        role: 'admin',
+      },
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid role values', async () => {
+    req.body.role = 'superadmin';
+
+    await updateUserRole(req, res, next);
+
+    expect(User.findById).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      statusCode: 400,
+      message: 'Role must be either user or admin',
+      data: {},
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('blocks admins from downgrading their own role', async () => {
+    req.userId = '507f1f77bcf86cd799439011';
+    req.body.role = 'user';
+
+    await updateUserRole(req, res, next);
+
+    expect(User.findById).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      statusCode: 403,
+      message: 'You cannot downgrade your own role',
+      data: {},
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the user does not exist', async () => {
+    User.findById.mockResolvedValue(null);
+
+    await updateUserRole(req, res, next);
+
+    expect(User.findById).toHaveBeenCalledWith('507f1f77bcf86cd799439011');
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      statusCode: 404,
+      message: 'User not found',
+      data: {},
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/src/controllers/admin.users.controller.js
+++ b/src/controllers/admin.users.controller.js
@@ -86,8 +86,51 @@ const listUsers = async (req, res, next) => {
   }
 };
 
+/**
+ * Update a user role (admin only)
+ * @route PATCH /api/admin/users/:id/role
+ * @access Admin only
+ */
+const updateUserRole = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const { role } = req.body;
+
+    const validRoles = ['user', 'admin'];
+    if (!role || !validRoles.includes(role)) {
+      return sendError(res, 'Role must be either user or admin', 400);
+    }
+
+    if (req.userId === id && role === 'user') {
+      return sendError(res, 'You cannot downgrade your own role', 403);
+    }
+
+    const user = await User.findById(id);
+    if (!user) {
+      return sendError(res, 'User not found', 404);
+    }
+
+    user.role = role;
+    await user.save();
+
+    return sendSuccess(
+      res,
+      {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+      },
+      200,
+      'User role updated successfully'
+    );
+  } catch (error) {
+    next(error);
+  }
+};
+
 module.exports = {
   deleteUser,
   restoreUser,
   listUsers,
+  updateUserRole,
 };

--- a/src/models/User.model.js
+++ b/src/models/User.model.js
@@ -84,10 +84,10 @@ const userSchema = new mongoose.Schema(
       type: Date,
       default: null,
     },
-  },
-  {
     timestamps: true,
   }
+}
+
 );
 
 // Middleware to exclude soft-deleted users from all queries

--- a/src/routes/admin.routes.js
+++ b/src/routes/admin.routes.js
@@ -5,6 +5,7 @@ const {
   deleteUser,
   restoreUser,
   listUsers,
+  updateUserRole,
 } = require('../controllers/admin.users.controller');
 
 const router = express.Router();
@@ -21,5 +22,8 @@ router.delete('/users/:id', deleteUser);
 
 // POST /api/admin/users/:id/restore - Restore a soft-deleted user
 router.post('/users/:id/restore', restoreUser);
+
+// PATCH /api/admin/users/:id/role - Update a user role
+router.patch('/users/:id/role', updateUserRole);
 
 module.exports = router;


### PR DESCRIPTION
- Create PATCH /api/admin/users/:id/role endpoint
- Require admin role and validate role values (user | admin)
- Prevent admins from downgrading their own role
- Return updated user with id, email, and role
- Add comprehensive unit tests for role update scenarios

closes #57 